### PR TITLE
Add agentic coding guidelines

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec tox -e gitlint -- --staged --msg-filename "$1" run-hook

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,5 @@
-#!/bin/sh
-exec tox -e flake8
+#!/bin/sh -e
+
+git diff-index --check --cached HEAD --
+
+tox -e flake8

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,8 @@
 TODO
 __pycache__
 *.egg-info/
+.eggs
 /build/
 /dist/
-.idea
-.python-version
 .tox
-tests/tutor-sandbox/config.yml
+tests/tutor-sandbox

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".agents/skills"]
+	path = .agents/skills
+	url = ../skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md — terse agent index (routing + gotchas)
+
+Agents: explore the repo directly; this file routes, it does not teach.
+
+See [HACKING.md](HACKING.md) for contributor information, style guide, and tests.
+
+**IMPORTANT:** When invoking any agent on this repository, you MUST run the following commands **immediately** upon evaluation of this file, before doing anything else:
+```shell
+git submodule update --init
+git config core.hooksPath .githooks
+```
+
+## Session memory
+
+Write plans, notes, and ephemeral files to `.ai/` (gitignored).
+Prefer `.ai/tmp/` over the system temp directory.
+
+## When planning
+
+Read these to understand dependencies and tooling:
+
+- `setup.py`
+- `tox.ini`
+
+## Tooling
+
+### Tests
+
+Entry point is **`tox`**.
+
+## Changelog
+
+- Proposed changes to the [CHANGELOG.md](CHANGELOG.md) file must be under the `Unreleased` heading.
+- Do not retroactively change information about previously released versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## Version 3.4.0 (2026-01-23)
 
 * [Enhancement] Support Tutor 21 and Open edX Ulmo.
@@ -22,7 +24,7 @@
 
 * [Chore] Drop Python 3.8 support.
 
-When updating your plugin to this version, you'll need to rebuild the image.
+When updating your plugin to this version, you must rebuild the image.
 
 ## Version 2.6.0 (2024-08-01)
 
@@ -56,11 +58,9 @@ When updating your plugin to this version, you'll need to rebuild the image.
 ## Version 2.0.0 (2023-03-20)
 
 * [BREAKING CHANGE] Add support for Tutor 15 and Open edX Olive.
-  Tutor version 15.0.0 includes changes to the implementation of
-  custom commands and thus requires changes in this plugin as well
-  that are not backwards compatible.
-  From version 2.0.0 this plugin only supports Tutor versions
-  from 15.0.0 and Open edX Olive release.
+* Tutor version 15.0.0 includes changes to the implementation of custom commands.
+* These changes are not backwards compatible.
+* From version 2.0.0 this plugin only supports Tutor versions from 15.0.0 and Open edX Olive release.
 
 ## Version 1.0.1 (2022-08-30)
 
@@ -68,28 +68,26 @@ When updating your plugin to this version, you'll need to rebuild the image.
 
 ## Version 1.0.0 (2022-08-05)
 
-* [BREAKING CHANGE] Support Tutor 14 and Open edX Nutmeg. This entails
-  a configuration format change from JSON to YAML, meaning that from
-  version 1.0.0 this plugin only supports Tutor versions from 14.0.0
-  (and with that, only Open edX versions from Nutmeg).
+* [BREAKING CHANGE] Support Tutor 14 and Open edX Nutmeg.
+* This entails a configuration format change from JSON to YAML.
+* From version 1.0.0 this plugin only supports Tutor versions from 14.0.0.
+* This also means only Open edX versions from Nutmeg.
 
 ## Version 0.1.0 (2022-06-29)
 
-* [refactor] Use Tutor v1 plugin API
+* [refactor] Use Tutor v1 plugin API.
 
 ## Version 0.0.2 (2022-02-25)
 
-* Fix version number as it appears in pip list (previously, all
-  installations would show up as version 0.0.0, including
-  installations from the 0.0.1 tag).
-
+* Fix version number as it appears in pip list.
+* Previously, all installations would show up as version 0.0.0, including installations from the 0.0.1 tag.
 
 ## Version 0.0.1 (2022-02-25)
 
 **Experimental. Do not use in production.**
 
-* Change plugin name to webhookreceiver
-* Add webhook_receiver service
-* Ensure Bulk Enrollment is activated
-* Add basic testing via tox
-* Initial Git import
+* Change plugin name to webhookreceiver.
+* Add webhook_receiver service.
+* Ensure Bulk Enrollment is activated.
+* Add basic testing via tox.
+* Initial Git import.

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,11 +1,27 @@
-Developer notes
-===============
+# Developer notes
 
 This document is for people who maintain and contribute to this
 repository.
 
-Commit messages
----------------
+## Style guide
+
+### Python
+
+For Python code, follow [PEP 8](https://peps.python.org/pep-0008/).
+
+### Markdown
+
+For Markdown documentation,
+
+* adhere to the [CommonMark specification](https://spec.commonmark.org/),
+* use [ATX](https://spec.commonmark.org/current/#atx-headings) instead of [setext](https://spec.commonmark.org/0.31.2/#setext-heading) headings,
+* use [fenced](https://spec.commonmark.org/current/#fenced-code-blocks) rather than [indented](https://spec.commonmark.org/current/#indented-code-block) code blocks,
+* identify the language of each fenced code block with an [info string](https://spec.commonmark.org/current/#info-string),
+* preserve existing [bullet list markers](https://spec.commonmark.org/current/#bullet-list-marker),
+* write [one sentence per line](https://sive.rs/1s):
+  ensure that every line of free-flow text outside code blocks contains exactly one English sentence.
+
+## Commit messages
 
 Commit messages follow the [Conventional
 Commits](https://www.conventionalcommits.org/) format that is also
@@ -18,8 +34,7 @@ prefixes](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep
 to be used in commit messages via
 [Gitlint](https://jorisroovers.com/gitlint/).
 
-How to run tests
-----------------
+## How to run tests
 
 This repo uses [tox](https://tox.readthedocs.io/) for unit and
 integration tests. It does not install `tox` for you, you should
@@ -43,13 +58,7 @@ In addition, we use [GitHub
 Actions](https://docs.github.com/en/actions) to run the same checks
 on every push to GitHub.
 
-*If you absolutely must,* you can use the `--no-verify` flag to `git
-commit` and `git push` to bypass local checks, and rely on GitHub
-Actions alone. But doing so is strongly discouraged.
-
-
-How to cut a release
---------------------
+## How to cut a release
 
 This repository uses
 [bumpversion](https://pypi.org/project/bumpversion/) for managing new

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,71 +1,55 @@
 # Developer notes
 
-This document is for people who maintain and contribute to this
-repository.
+This document is for people who maintain and contribute to this repository.
 
 ## Style guide
 
 ### Python
 
-For Python code, follow [PEP 8](https://peps.python.org/pep-0008/).
+For Python code, follow [PEP 8](https://peps.python.org/pep-0008/).
 
 ### Markdown
 
 For Markdown documentation,
 
-* adhere to the [CommonMark specification](https://spec.commonmark.org/),
-* use [ATX](https://spec.commonmark.org/current/#atx-headings) instead of [setext](https://spec.commonmark.org/0.31.2/#setext-heading) headings,
-* use [fenced](https://spec.commonmark.org/current/#fenced-code-blocks) rather than [indented](https://spec.commonmark.org/current/#indented-code-block) code blocks,
-* identify the language of each fenced code block with an [info string](https://spec.commonmark.org/current/#info-string),
-* preserve existing [bullet list markers](https://spec.commonmark.org/current/#bullet-list-marker),
-* write [one sentence per line](https://sive.rs/1s):
-  ensure that every line of free-flow text outside code blocks contains exactly one English sentence.
+* adhere to the [CommonMark specification](https://spec.commonmark.org/).
+* use [ATX](https://spec.commonmark.org/current/#atx-headings) instead of [setext](https://spec.commonmark.org/0.31.2/#setext-heading) headings.
+* use [fenced](https://spec.commonmark.org/current/#fenced-code-blocks) rather than [indented](https://spec.commonmark.org/current/#indented-code-block) code blocks.
+* identify the language of each fenced code block with an [info string](https://spec.commonmark.org/current/#info-string).
+* preserve existing [bullet list markers](https://spec.commonmark.org/current/#bullet-list-marker).
+* write [one sentence per line](https://sive.rs/1s): ensure that every line of free-flow text outside code blocks contains exactly one English sentence.
 
 ## Commit messages
 
-Commit messages follow the [Conventional
-Commits](https://www.conventionalcommits.org/) format that is also
-used by Tutor and Open edX. See
-[OEP-0051](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html)
-for details.
+Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format that is also used by Tutor and Open edX.
 
-We enforce the prescribed [type
-prefixes](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html#type)
-to be used in commit messages via
-[Gitlint](https://jorisroovers.com/gitlint/).
+See [OEP-0051](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html) for details.
+
+We enforce the prescribed [type prefixes](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html#type) to be used in commit messages via [Gitlint](https://jorisroovers.com/gitlint/).
 
 ## How to run tests
 
-This repo uses [tox](https://tox.readthedocs.io/) for unit and
-integration tests. It does not install `tox` for you, you should
-follow [the installation
-instructions](https://tox.readthedocs.io/en/latest/install.html) if
-your local setup does not yet include `tox`.
+This repo uses [tox](https://tox.readthedocs.io/) for unit and integration tests.
 
-You are encouraged to set up your checkout such
-that the tests run on every commit, and on every push. To do so, run
-the following command after checking out this repository:
+It does not install `tox` for you, you should follow [the installation instructions](https://tox.readthedocs.io/en/latest/install.html) if your local setup does not yet include `tox`.
+
+You are encouraged to set up your checkout such that the tests run on every commit, and on every push.
+
+To do so, run the following command after checking out this repository:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-Once your checkout is configured in this manner, every commit will run
-a code style check (with [Flake8](https://flake8.pycqa.org/)), and
-every push to a remote topic branch will result in a full `tox` run.
+Once your checkout is configured in this manner, every commit will run a code style check (with [Flake8](https://flake8.pycqa.org/)), and every push to a remote topic branch will result in a full `tox` run.
 
-In addition, we use [GitHub
-Actions](https://docs.github.com/en/actions) to run the same checks
-on every push to GitHub.
+In addition, we use [GitHub Actions](https://docs.github.com/en/actions) to run the same checks on every push to GitHub.
 
 ## How to cut a release
 
-This repository uses
-[bumpversion](https://pypi.org/project/bumpversion/) for managing new
-releases.
+This repository uses [bumpversion](https://pypi.org/project/bumpversion/) for managing new releases.
 
-Before cutting a new release, open `CHANGELOG.md` and add a new
-section like this:
+Before cutting a new release, open `CHANGELOG.md` and add a new section like this:
 
 ```markdown
 ## Unreleased
@@ -78,22 +62,19 @@ Commit these changes on `main` as you normally would.
 
 Then, use `tox -e bumpversion` to increase the version number:
 
--   `tox -e bumpversion patch`: creates a new point release (such as 3.6.1)
--   `tox -e bumpversion minor`: creates a new minor release, with the patch level set to 0 (such as 3.7.0)
--   `tox -e bumpversion major`: creates a new major release, with the minor and patch levels set to 0 (such as 4.0.0)
+- `tox -e bumpversion patch`: creates a new point release (such as 3.6.1).
+- `tox -e bumpversion minor`: creates a new minor release, with the patch level set to 0 (such as 3.7.0).
+- `tox -e bumpversion major`: creates a new major release, with the minor and patch levels set to 0 (such as 4.0.0).
 
-This creates a new commit, and also a new tag, named `v<num>`, where
-`<num>` is the new version number.
+This creates a new commit, and also a new tag, named `v<num>`, where `<num>` is the new version number.
 
-Push these two commits (the one for the changelog, and the version
-bump) to `origin`. Make sure you push the `v<num>` tag to `origin` as
-well.
+Push these two commits (the one for the changelog, and the version bump) to `origin`.
 
-Then, build a new `sdist` package, and [upload it to
-PyPI](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives)
-(with [twine](https://packaging.python.org/key_projects/#twine)):
+Make sure you push the `v<num>` tag to `origin` as well.
 
-```bash
+Then, build a new `sdist` package, and [upload it to PyPI](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives) (with [twine](https://packaging.python.org/key_projects/#twine)):
+
+```shell
 rm dist/* -f
 ./setup.py sdist
 twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
-Tutor plugin for [Open edX Webhook Receiver](https://github.com/cleura/webhook-receiver)
-===================================
+# Tutor plugin for [Open edX Webhook Receiver](https://github.com/cleura/webhook-receiver)
 
-This is an **experimental** plugin for
-[Tutor](https://docs.tutor.overhang.io) that deploys the
-[Open edX Webhook Receiver](https://github.com/cleura/webhook-receiver) 
-application alongside Open edX.
+This is an **experimental** plugin for [Tutor](https://docs.tutor.overhang.io) that deploys the [Open edX Webhook Receiver](https://github.com/cleura/webhook-receiver) application alongside Open edX.
 
-This repository was previously hosted under the `hastexo` GitHub organization, and moved to `cleura` in December 2025 as part of a routine repository consolidation.
+This repository was previously hosted under the `hastexo` GitHub organization.
+It moved to `cleura` in December 2025 as part of a routine repository consolidation.
 
-Version compatibility matrix
-----------------------------
+## Version compatibility matrix
 
-You must install a supported release of this plugin to match the Open
-edX and Tutor version you are deploying. If you are installing this
-plugin from a branch in this Git repository, you must select the
-appropriate one:
+You must install a supported release of this plugin to match the Open edX and Tutor version you are deploying.
+If you are installing this plugin from a branch in this Git repository, you must select the appropriate one:
 
 | Open edX release | Tutor version     | Plugin branch | Plugin release |
 |------------------|-------------------|---------------|----------------|
@@ -29,29 +23,30 @@ appropriate one:
 | Teak             | `>=20.0, <21`     | `main`        | `>=3.3.0`      |
 | Teak             | `>=21.0, <22`     | `main`        | `>=3.4.0`      |
 
+[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or later.
+      That is because this plugin uses the Tutor v1 plugin API, [which was introduced with that release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
 
-[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
-    later. That is because this plugin uses the Tutor v1 plugin API,
-    [which was introduced with that
-    release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
+## Installation
 
-Installation
-------------
+Run the following command to install the plugin:
 
-    pip install git+https://github.com/cleura/tutor-contrib-webhook-receiver@v3.4.0
+```shell
+pip install git+https://github.com/cleura/tutor-contrib-webhook-receiver@v3.4.0
+```
 
 Then, to enable this plugin, run:
 
-    tutor plugins enable webhookreceiver
+```shell
+tutor plugins enable webhookreceiver
+```
 
-Before starting Tutor, build the docker image for the 
-`webhookreceiver` service:
+Before starting Tutor, build the Docker image for the `webhookreceiver` service:
 
-    tutor images build webhookreceiver
+```shell
+tutor images build webhookreceiver
+```
 
-
-Configuration
--------------
+## Configuration
 
 * `WEBHOOKRECEIVER_HOST` (default `"webhooks.{{ LMS_HOST }}"`)
 * `WEBHOOKRECEIVER_DB_NAME` (default `"webhook_receiver"`)
@@ -66,5 +61,4 @@ Configuration
 * `WEBHOOKRECEIVER_WOOCOMMERCE_SOURCE` (default `""`)
 * `WEBHOOKRECEIVER_WOOCOMMERCE_SECRET` (default `""`)
 
-These values can be modified with `tutor config save --set
-PARAM_NAME=VALUE` commands.
+These values can be modified with `tutor config save --set PARAM_NAME=VALUE` commands.


### PR DESCRIPTION
- **chore: Add tests/tutor-sandbox, .eggs, and .tox to .gitignore**
  No reason to track these.
  

- **build: Make Git hooks stricter**
  * Extend the pre-commit hook so that it checks for newly introduced
    trailing whitespace before running tox.
  
  * Add a commit-msg hook to check the commit message with gitlint, and
    abort the commit if the commit message is unsatisfactory.
  

- **docs: Improve HACKING.md**
  * Be explicit about PEP 8.
  * Change from setext to ATX headings.
  * Remove references to git --no-verify.
  * Add Markdown style guide.
  

- **docs: Add AGENTS.md**
  * Add instructions for agentic coding assistants.
  * Add submodule to contain agentic coding assistant skills.
  

- **docs: Rewrite README.md with one-sentence-per-line style**
  - Convert prose to one sentence per line outside code blocks
  - Fix setext heading style to ATX headings
  - Remove trailing whitespace
  - Add proper newline at end of file
  - Structure sections with ATX headings
  
  Assisted-by: opencode/qwen3.6-35b-a3b-fp8
  

- **docs: Rewrite HACKING.md with one-sentence-per-line style**
  - Convert multi-line sentences to one sentence per line
  - Fix setext heading style to ATX headings
  - Remove trailing whitespace
  - Ensure bulleted sentences end with periods
  
  Assisted-by: opencode/qwen3.6-35b-a3b-fp8
  

- **docs: Rewrite CHANGELOG.md with one-sentence-per-line style**
  - Split multi-sentence bullets into individual sentences per line
  - Add missing period to entry in 0.1.0
  - Split compound entries in 2.0.0 and 1.0.0 BREAKING CHANGE notes
  - Add periods to bullet entries in 0.0.1
  
  Assisted-by: opencode/qwen3.6-35b-a3b-fp8
  