### PR TITLE
feat: Add support for Tutor 22 / Open edX Verawood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [Enhancement] Support Tutor 22 and Open edX Verawood.
 * [Testing] Set skip_missing_interpreters = true for tox, so that it runs with whatever Python is available.
 
 ## Version 3.4.0 (2026-01-23)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ If you are installing this plugin from a branch in this Git repository, you must
 | Redwood          | `>=18.0, <19`     | `main`        | `>=3`          |
 | Sumac            | `>=19.0, <20`     | `main`        | `>=3.2.0`      |
 | Teak             | `>=20.0, <21`     | `main`        | `>=3.3.0`      |
-| Teak             | `>=21.0, <22`     | `main`        | `>=3.4.0`      |
+| Ulmo             | `>=21.0, <22`     | `main`        | `>=3.4.0`      |
+| Verawood         | `>=22.0, <23`     | `main`        | `>=3.5.0`      |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or later.
       That is because this plugin uses the Tutor v1 plugin API, [which was introduced with that release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <22, >=15.0.0"],
+    install_requires=["tutor <23, >=15.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [


### PR DESCRIPTION
* Update the install_requires list to support Tutor 22.
* Update the compatibility matrix in the README accordingly.